### PR TITLE
Add arm64 support to release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           ansible-builder create -v3 --output-file=Dockerfile
           docker buildx build \
             --push \
-            --platform=linux/amd64 \
+            --platform=linux/amd64,linux/arm64 \
             --tag=${{ vars.IMAGE_REGISTRY }}:${{ github.event.release.tag_name }} \
             context
 


### PR DESCRIPTION
Arm support was added to the CI for the `latest` tag, but not the release.