### PR TITLE
Update packages, use 'alternatives' for python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,15 @@ on:
     types:
       - created
   schedule:
-    # build and push nightly
-    - cron: "13 4 * * *"
+    # build and push weekly
+    - cron: "13 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registry after build'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   ci:
@@ -59,9 +66,9 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -77,12 +84,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
+    # Run if push_image input is true, or if the input is not provided (triggers other than workflow_dispatch)
+    if: ${{ github.event.inputs.push_image == 'true' || github.event.inputs.push_image == null || github.event.inputs.push_image == '' }}
     strategy:
       fail-fast: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -8,7 +8,7 @@ dependencies:
     # A minimum of 2.15 is required to get ansible-inventory --limit option
     package_pip: ansible-core==2.16.14
   ansible_runner:
-    package_pip: ansible-runner>=2.4.0
+    package_pip: ansible-runner>=2.4.2
   python_interpreter:
     package_system: python3.12
     python_path: "/usr/bin/python3.12"
@@ -67,8 +67,8 @@ dependencies:
 additional_build_steps:
   append_base:
     - RUN $PYCMD -m pip install -U pip
-    - RUN unlink /usr/bin/python3 && ln -s /usr/bin/python3.12 /usr/bin/python3
+    - RUN alternatives --install /usr/bin/python python /usr/bin/python3.12 312
   append_final:
-    - COPY --from=quay.io/ansible/receptor:v1.5.2 /usr/bin/receptor /usr/bin/receptor
+    - COPY --from=quay.io/ansible/receptor:v1.6.1 /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system


### PR DESCRIPTION
Update ansible-runner to 2.4.2
Update receptor to 1.6.1
Use 'alternatives' instead of direct symlink for python 3.12