### PR TITLE
Add collections and overhaul CI/CD workflows

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -52,8 +52,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Get latest tag, default to 0.0.0 if none exist
-          CURRENT=$(gh api repos/${{ github.repository }}/tags --jq '.[0].name // "v0.0.0"' | sed 's/^v//')
+          # Find highest semver tag (numeric sort, ignoring pre-release suffixes like -rc0)
+          CURRENT=$(gh api repos/${{ github.repository }}/tags --paginate --jq '.[].name' \
+            | sed -n 's/^v\?\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -1)
+          CURRENT="${CURRENT:-0.0.0}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
           case "${{ steps.bump.outputs.type }}" in

--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -1,12 +1,24 @@
 name: "Create Tag on Pull Request merge"
+
+# Configurable version bump labels
+# Change these to match your preferred label names
+env:
+  LABEL_MAJOR: "release/major"
+  LABEL_MINOR: "release/minor"
+  LABEL_PATCH: "release/patch"
+
 on:
   pull_request:
     types:
+      - opened
+      - synchronize
+      - labeled
+      - unlabeled
       - closed
     branches:
       - main
     paths:
-      - "./**"
+      - "**"
       - '!**/*.md'
 
 jobs:
@@ -18,61 +30,90 @@ jobs:
       contents: write
 
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
-      - name: Generate Tag
+      - name: Determine version bump type
+        id: bump
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q "\"$LABEL_MAJOR\""; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "\"$LABEL_MINOR\""; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "\"$LABEL_PATCH\""; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            echo "type=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Calculate new version
         id: tagged
+        if: steps.bump.outputs.type != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo $(curl \
-            --silent \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-            "https://api.github.com/repos/${{ github.repository }}/tags" \
-            | jq -r '.[].name |= sub("-rc0|v"; "";"g") | select(length > 1) | max_by(.name) | .name' \
-            | awk '
-            function inc(s){
-              split(s, a, ".")
-              a[3]++
-              if (a[3]>=10){
-                a[2]++;a[3]=0
-              }
-              if (a[2]>=10){
-                a[1]++;a[2]=0
-              }
-              return a[1]"."a[2]"."a[3]
+          # Get latest tag, default to 0.0.0 if none exist
+          CURRENT=$(gh api repos/${{ github.repository }}/tags --jq '.[0].name // "v0.0.0"' | sed 's/^v//')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
 
-            }
-            { print "newtag="inc($1) }') >> $GITHUB_OUTPUT
+          case "${{ steps.bump.outputs.type }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
 
-      - name: Create new tag in github
-        id: createtag
+          NEWTAG="${MAJOR}.${MINOR}.${PATCH}"
+          echo "newtag=${NEWTAG}" >> $GITHUB_OUTPUT
+          echo "current=${CURRENT}" >> $GITHUB_OUTPUT
+
+      - name: Job summary (dry-run)
+        if: github.event.pull_request.merged != true
         run: |
-          echo tag_sha=$(curl \
-            --silent \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-            "https://api.github.com/repos/${{ github.repository }}/git/tags" \
-            -d '{"tag":"v${{ steps.tagged.outputs.newtag }}","message":"New release from github actions","object":"${{ github.sha }}","type":"commit"}' \
-            | jq -r '.sha') >> $GITHUB_OUTPUT
+          if [[ -n "${{ steps.bump.outputs.type }}" ]]; then
+            echo "## Release Preview" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "When this PR is merged, a **${{ steps.bump.outputs.type }}** release will be created:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- Current version: \`v${{ steps.tagged.outputs.current }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "- New version: \`v${{ steps.tagged.outputs.newtag }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## No Release Scheduled" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This PR does not have a version label. No release will be created on merge." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To create a release when this PR is merged, add one of these labels:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Label | Description |" >> $GITHUB_STEP_SUMMARY
+            echo "|-------|-------------|" >> $GITHUB_STEP_SUMMARY
+            echo "| \`$LABEL_PATCH\` | Bug fixes, backwards compatible |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`$LABEL_MINOR\` | New features, backwards compatible |" >> $GITHUB_STEP_SUMMARY
+            echo "| \`$LABEL_MAJOR\` | Breaking changes |" >> $GITHUB_STEP_SUMMARY
+          fi
 
-      - name: Create ref tag in github
-        id: createreftag
+      - name: Create tag
+        if: github.event.pull_request.merged == true && steps.bump.outputs.type != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl \
-            --silent \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-            "https://api.github.com/repos/${{ github.repository }}/git/refs" \
-            -d '{"ref": "refs/tags/v${{ steps.tagged.outputs.newtag }}",  "sha": "${{ steps.createtag.outputs.tag_sha}}" }'
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/tags/v${{ steps.tagged.outputs.newtag }}" \
+            -f sha="${{ github.sha }}"
 
-      - name: Add PR comment with new tag info
+          echo "::notice::Created tag v${{ steps.tagged.outputs.newtag }}"
+
+      - name: Job summary (released)
+        if: github.event.pull_request.merged == true && steps.bump.outputs.type != ''
         run: |
-          curl \
-            --silent \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
-            "${{ github.event.pull_request._links.comments.href }}" \
-            -d '{"body":"Created tag v${{ steps.tagged.outputs.newtag }}"}'
+          echo "## Release Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Created tag \`v${{ steps.tagged.outputs.newtag }}\` (${{ steps.bump.outputs.type }} bump from v${{ steps.tagged.outputs.current }})" >> $GITHUB_STEP_SUMMARY
+
+      - name: Comment on PR
+        if: github.event.pull_request.merged == true && steps.bump.outputs.type != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "Created tag v${{ steps.tagged.outputs.newtag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,27 @@
 ---
-# This workflow will build and push an AWX EE image to a container registry based upon the provided configuration
+# This workflow builds an AWX EE image and optionally pushes it to a container registry.
 #
-# Image tags will be generated based upon the event that triggered the workflow:
-#   - push event:
+# Jobs:
+#   ci: Runs on all triggers. Builds the image with Podman to validate the build.
+#   release: Pushes the image to the registry. Only runs on:
+#     - release: when a GitHub release is created
+#     - schedule: weekly nightly builds
+#     - workflow_dispatch: when manually triggered with push_image=true
+#
+# To push an image for a specific branch:
+#   1. Go to Actions > "Build & Release" workflow
+#   2. Click "Run workflow"
+#   3. Select the target branch
+#   4. Check "Push image to registry after build"
+#   5. Click "Run workflow"
+#
+# Image tags:
+#   - release event: <tag_name> (e.g., v1.0.0)
+#   - schedule event: nightly
+#   - workflow_dispatch:
 #     - main branch: latest
 #     - devel branch: devel
-#     - all other branches: <branch name>-latest
-#       Branches must be added to the on.push.branches array above to trigger
-#   - pull_request event: DEV-PR-<pull_request_number>
-#     Branches must be added to the on.pull_request.branches array above to trigger
-#   - release event: <tag_name>
-#   - schedule event: nightly
-#     This will be the same configuration as the 'latest' tag, but may contain updated packages, etc. from upstream
-#   - all other events: <first 7 chars of commit sha>
+#     - other branches: <branch_name>-latest
 #
 # Variables:
 #   IMAGE_REGISTRY_URL: The container registry to push the image to (default: ghcr.io)
@@ -27,29 +36,27 @@ name: Build & Release
 
 on:
   push:
-    # build and push anytime commits are merged to specified branches
+    # run CI build when commits are merged to specified branches
     branches:
       - main
       - devel
     paths:
-      - ".github/workflows/release.yml"
-      - "./**"
+      - "**"
       - '!**/*.md'
   pull_request:
-    # build and push anytime a pull request is opened or synchronized
+    # run CI build when a pull request is opened or synchronized
     branches:
       - main
       - devel
     paths:
-      - ".github/workflows/release.yml"
-      - "./**"
+      - "**"
       - '!**/*.md'
   release:
-    # build and push anytime a release is created
+    # build and push when a release is created
     types:
       - created
   schedule:
-    # build and push weekly
+    # build and push nightly image weekly
     - cron: "13 4 * * 1"
   workflow_dispatch:
     inputs:
@@ -84,8 +91,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Release
-    # Run if push_image input is true, or if the input is not provided (triggers other than workflow_dispatch)
-    if: ${{ github.event.inputs.push_image == 'true' || github.event.inputs.push_image == null || github.event.inputs.push_image == '' }}
+    # Only push images for releases, scheduled builds, or manual workflow_dispatch with push_image=true
+    if: ${{ github.event_name == 'release' || github.event_name == 'schedule' || github.event.inputs.push_image == 'true' }}
     strategy:
       fail-fast: true
     steps:
@@ -109,22 +116,16 @@ jobs:
 
       - name: Generate image tag
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            if [[ "${{ github.ref_name }}" == "main" ]]; then
-              echo "IMAGE_TAG=latest" >> $GITHUB_ENV
-            elif [[ "${{ github.ref_name }}" == "devel" ]]; then
-              echo "IMAGE_TAG=devel" >> $GITHUB_ENV
-            else
-              echo "IMAGE_TAG=${{ github.ref_name }}-latest" >> $GITHUB_ENV
-            fi
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "IMAGE_TAG=DEV-PR-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          elif [[ "${{ github.ref_name }}" == "devel" ]]; then
+            echo "IMAGE_TAG=devel" >> $GITHUB_ENV
           else
-            echo "IMAGE_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ github.ref_name }}-latest" >> $GITHUB_ENV
           fi
 
       - name: Build and push image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@
 #   - workflow_dispatch:
 #     - main branch: latest
 #     - devel branch: devel
-#     - other branches: <branch_name>-latest
+#     - branches with open PR: DEV-PR-<number>
+#     - other branches: DEV-<short-sha>
+#   - pull_request event: DEV-PR-<number>
 #
 # Variables:
 #   IMAGE_REGISTRY_URL: The container registry to push the image to (default: ghcr.io)
@@ -124,23 +126,37 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate image tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
             IMAGE_TAG="${{ github.event.release.tag_name }}"
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
             IMAGE_TAG="nightly"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            IMAGE_TAG="DEV-PR-${{ github.event.pull_request.number }}"
           elif [[ "${{ github.ref_name }}" == "main" ]]; then
             IMAGE_TAG="latest"
           elif [[ "${{ github.ref_name }}" == "devel" ]]; then
             IMAGE_TAG="devel"
           else
-            IMAGE_TAG="${{ github.ref_name }}-latest"
+            # For workflow_dispatch on feature branches, try to find associated PR
+            PR_NUMBER=$(gh pr list --head "${{ github.ref_name }}" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+            if [[ -n "$PR_NUMBER" ]]; then
+              IMAGE_TAG="DEV-PR-${PR_NUMBER}"
+            else
+              # Fallback: use short commit hash (first 7 chars)
+              SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+              IMAGE_TAG="DEV-${SHORT_SHA}"
+            fi
           fi
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo "::notice::Image tag: ${{ vars.IMAGE_REGISTRY_URL || 'ghcr.io' }}/${{ vars.IMAGE_REPOSITORY || github.repository }}:${IMAGE_TAG}"
 
           # Add ghcr.io tag if dual-push is enabled
           if [[ "${{ vars.ALWAYS_PUSH_GHCR }}" == "true" ]]; then
             echo "GHCR_TAG_ARG=--tag=ghcr.io/${{ github.repository }}:${IMAGE_TAG}" >> $GITHUB_ENV
+            echo "::notice::Also pushing to ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
           else
             echo "GHCR_TAG_ARG=" >> $GITHUB_ENV
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@
 #   IMAGE_REGISTRY_URL: The container registry to push the image to (default: ghcr.io)
 #   IMAGE_REPOSITORY: The repository to push the image to (default: github.repository)
 #   IMAGE_REGISTRY_USER: The username to authenticate with the container registry (default: github.actor)
+#   ALWAYS_PUSH_GHCR: Set to 'true' to also push images to ghcr.io (default: false)
 #
 # Secrets:
 #   IMAGE_REGISTRY_TOKEN: The token to authenticate with the container registry (default: secrets.GITHUB_TOKEN)
@@ -114,18 +115,34 @@ jobs:
           username: ${{ vars.IMAGE_REGISTRY_USER || github.actor }}
           password: ${{ secrets.IMAGE_REGISTRY_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        if: ${{ vars.ALWAYS_PUSH_GHCR == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate image tag
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+            IMAGE_TAG="${{ github.event.release.tag_name }}"
           elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "IMAGE_TAG=nightly" >> $GITHUB_ENV
+            IMAGE_TAG="nightly"
           elif [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+            IMAGE_TAG="latest"
           elif [[ "${{ github.ref_name }}" == "devel" ]]; then
-            echo "IMAGE_TAG=devel" >> $GITHUB_ENV
+            IMAGE_TAG="devel"
           else
-            echo "IMAGE_TAG=${{ github.ref_name }}-latest" >> $GITHUB_ENV
+            IMAGE_TAG="${{ github.ref_name }}-latest"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+
+          # Add ghcr.io tag if dual-push is enabled
+          if [[ "${{ vars.ALWAYS_PUSH_GHCR }}" == "true" ]]; then
+            echo "GHCR_TAG_ARG=--tag=ghcr.io/${{ github.repository }}:${IMAGE_TAG}" >> $GITHUB_ENV
+          else
+            echo "GHCR_TAG_ARG=" >> $GITHUB_ENV
           fi
 
       - name: Build and push image
@@ -136,6 +153,6 @@ jobs:
           docker buildx build \
             --push \
             --platform=linux/amd64,linux/arm64 \
-            --tag=${{ vars.IMAGE_REGISTRY_URL || 'ghcr.io' }}/${{ vars.IMAGE_REPOSITORY || github.repository }}:${{ env.IMAGE_TAG }} \
+            --tag=${{ vars.IMAGE_REGISTRY_URL || 'ghcr.io' }}/${{ vars.IMAGE_REPOSITORY || github.repository }}:${{ env.IMAGE_TAG }} ${{ env.GHCR_TAG_ARG }} \
             context
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,32 @@
 An Execution Environment for AWX.
 
 Main features:
-- Centos Stream 9
+- CentOS Stream 9
 - Python 3.12
-  - ara
-  - boto3
-  - mitogen
-  - redis
-  - toml
 - Ansible 2.16
-- Minimal base collections installed
+
+### Collections
+- `amazon.aws`
+- `ansible.posix`
+- `ansible.receptor`
+- `ansible.utils`
+- `awx.awx`
+- `community.aws`
+- `community.docker`
+- `community.general`
+- `community.grafana`
+
+### Python packages
+- ara
+- boto3
+- mitogen
+- netaddr
+- paramiko
+- pykerberos
+- pywinrm
+- receptorctl
+- redis
+- toml
 
 View the full configuration in the [execution-environment.yaml](execution-environment.yaml) file.
 

--- a/README.md
+++ b/README.md
@@ -27,5 +27,36 @@ $ ansible-builder build -v3 -t quay.io/influxdb/awx-ee --container-runtime=docke
 
 ## Build the image via CI
 
-The Github actions configuration in this repository should work for you as well, provided that you're using that platform. Just update the secrets to reflect your chosen container repository.
+The GitHub Actions workflow builds and publishes images automatically.
+
+### Automatic builds
+- **Releases**: Creating a GitHub release pushes an image tagged with the release name (e.g., `v1.0.0`)
+- **Nightly**: Weekly scheduled builds push a `nightly` tag
+
+### Manual builds
+To push an image for a specific branch:
+1. Go to Actions > "Build & Release" workflow
+2. Click "Run workflow"
+3. Select the target branch
+4. Check "Push image to registry after build"
+5. Click "Run workflow"
+
+Image tags for manual builds:
+| Branch | Tag |
+|--------|-----|
+| `main` | `latest` |
+| `devel` | `devel` |
+| Branch with open PR | `DEV-PR-<number>` |
+| Other branches | `DEV-<commit-sha>` |
+
+### CI validation
+Pull requests and pushes to `main`/`devel` trigger a CI build (Podman) to validate the image builds successfully, but do not push to the registry.
+
+### Configuration
+To use this workflow in your own fork, configure these repository variables/secrets:
+- `IMAGE_REGISTRY_URL`: Container registry URL (default: `ghcr.io`)
+- `IMAGE_REPOSITORY`: Image repository path (default: `github.repository`)
+- `IMAGE_REGISTRY_USER`: Registry username (default: `github.actor`)
+- `IMAGE_REGISTRY_TOKEN` (secret): Registry auth token (default: `GITHUB_TOKEN`)
+- `ALWAYS_PUSH_GHCR`: Set to `true` to also push to `ghcr.io` when using an alternate primary registry
 

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -16,11 +16,18 @@ dependencies:
     ---
     collections:
       - name: awx.awx
+        version: 24.5.0
       - name: amazon.aws
+        version: ">=9.3.0"
       - name: ansible.posix
+      - name: ansible.receptor
+        version: ">=2.0.8"
+      - name: ansible.utils
+      - name: community.aws
       - name: community.general
       - name: community.docker
-      - name: community.aws
+        version: ">=3.10.2"
+      - name: community.grafana
   system: |
     git-core [platform:rpm]
     python3.12-devel [platform:rpm compile]

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -76,6 +76,6 @@ additional_build_steps:
     - RUN $PYCMD -m pip install -U pip
     - RUN alternatives --install /usr/bin/python python /usr/bin/python3.12 312
   append_final:
-    - COPY --from=quay.io/ansible/receptor:v1.6.1 /usr/bin/receptor /usr/bin/receptor
+    - COPY --from=quay.io/ansible/receptor:v1.6.3 /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system


### PR DESCRIPTION
## Collections
- Add `ansible.receptor`, `ansible.utils`, `community.aws`, `community.grafana`
- Pin `awx.awx` to 24.5.0, `amazon.aws` to >=9.3.0
- Bump receptor to v1.6.3

## CI/CD
- Add label-based semver tagging on merge (`release/major`, `release/minor`, `release/patch`)
- Show release preview in job summary for open PRs
- Add optional dual-registry push to ghcr.io (`ALWAYS_PUSH_GHCR`)
- Fix path filters, only run release job on demand

## Docs
- Add CI workflow documentation to README